### PR TITLE
Add pypenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,6 +881,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 * [Curdling](http://clarete.li/curdling/) - Curdling is a command line tool for managing Python packages.
 * [pip-tools](https://github.com/jazzband/pip-tools) - A set of tools to keep your pinned Python dependencies fresh.
 * [wheel](http://pythonwheels.com/) - The new standard of Python distribution and are intended to replace eggs.
+* [pipenv](https://github.com/pypa/pipenv) - Python Dev Workflow for Humans.
 
 ## Package Repositories
 


### PR DESCRIPTION
## What is this Python project?

Pipenv — the officially recommended Python packaging tool from Python.org, free (as in freedom).

## What's the difference between this Python project and similar ones?

Pipenv is a tool that aims to bring the best of all packaging worlds (bundler, composer, npm, cargo, yarn, etc.) to the Python world. Windows is a first-class citizen, in our world.

It automatically creates and manages a virtualenv for your projects, as well as adds/removes packages from your Pipfile as you install/uninstall packages. It also generates the ever-important Pipfile.lock, which is used to produce deterministic builds.

